### PR TITLE
Add the missing data table to the chart

### DIFF
--- a/openpyxl/chart/reader.py
+++ b/openpyxl/chart/reader.py
@@ -12,6 +12,7 @@ def read_chart(chartspace):
     chart._charts = plot._charts
 
     chart.title = cs.chart.title
+    chart.plot_area = plot
     chart.display_blanks = cs.chart.dispBlanksAs
     chart.visible_cells_only = cs.chart.plotVisOnly
     chart.layout = plot.layout

--- a/openpyxl/chart/tests/test_reader.py
+++ b/openpyxl/chart/tests/test_reader.py
@@ -6,6 +6,7 @@ from .. bar_chart import BarChart
 from .. line_chart import LineChart
 from .. axis import NumericAxis, DateAxis
 from .. chartspace import ChartSpace, ChartContainer
+from ..plotarea import PlotArea, DataTable
 
 
 def test_read(datadir):
@@ -65,3 +66,20 @@ def test_read_chart_with_shapes(datadir):
     assert chart.graphical_properties.noFill
     assert chart.graphical_properties.line.noFill
 
+
+def test_read_chart_plot_area():
+    from ..reader import read_chart
+
+    container = ChartContainer()
+    plot_area = PlotArea()
+    plot_area._charts = [BarChart()]
+    plot_area.dTable = DataTable()
+    container.plotArea = plot_area
+    cs = ChartSpace(chart=container)
+
+    chart = read_chart(cs)
+
+    assert chart.plot_area is not None
+    assert chart.plot_area == cs.chart.plotArea
+    assert chart.plot_area._charts == [chart]
+    assert chart.plot_area.dTable == cs.chart.plotArea.dTable


### PR DESCRIPTION
Fix this behaviour: When a workbook containing a chart with a Data Table is loaded and then saved using openpyxl, the Data Table is not preserved in the saved file

Issue: [https://foss.heptapod.net/openpyxl/openpyxl/-/issues/2228]( https://foss.heptapod.net/openpyxl/openpyxl/-/issues/2228)