### PR TITLE
Retain View3D for BarChart3D when saving workbook

### DIFF
--- a/openpyxl/chart/_chart.py
+++ b/openpyxl/chart/_chart.py
@@ -147,6 +147,9 @@ class ChartBase(Serialisable):
         cs.roundedCorners = self.roundedCorners
         cs.pivotSource = self.pivotSource
         cs.spPr = self.graphical_properties
+        view3D = getattr(self, "view3D", None)
+        if view3D is not None:
+            cs.chart.view3D = view3D
         return cs.to_tree()
 
 

--- a/openpyxl/chart/reader.py
+++ b/openpyxl/chart/reader.py
@@ -26,6 +26,7 @@ def read_chart(chartspace):
     chart.pivotFormats = cs.chart.pivotFmts
     chart.idx_base = min((s.idx for s in chart.series), default=0)
     chart._reindex()
+    chart.view3D = cs.chart.view3D
 
     # Border, fill, etc.
     chart.graphical_properties = cs.graphical_properties

--- a/openpyxl/chart/tests/test_reader.py
+++ b/openpyxl/chart/tests/test_reader.py
@@ -2,7 +2,8 @@
 
 from openpyxl.xml.functions import fromstring
 
-from .. bar_chart import BarChart
+from .._3d import View3D
+from ..bar_chart import BarChart, BarChart3D
 from .. line_chart import LineChart
 from .. axis import NumericAxis, DateAxis
 from .. chartspace import ChartSpace, ChartContainer
@@ -83,3 +84,23 @@ def test_read_chart_plot_area():
     assert chart.plot_area == cs.chart.plotArea
     assert chart.plot_area._charts == [chart]
     assert chart.plot_area.dTable == cs.chart.plotArea.dTable
+
+
+def test_read_chart_view3D():
+    from ..reader import read_chart
+
+    container = ChartContainer()
+    view3D = View3D()
+    container.view3D = view3D
+    plot_area = PlotArea()
+    plot_area._charts = [BarChart3D()]
+    container.plotArea = plot_area
+    cs = ChartSpace(chart=container)
+
+    chart = read_chart(cs)
+
+    assert chart.view3D is not None
+    assert chart.view3D == cs.chart.view3D
+    assert chart.view3D.rotX == 15
+    assert chart.view3D.perspective is None
+    assert chart.view3D.hPercent is None


### PR DESCRIPTION
Prevent loss of chart rotation format by ensuring the View3D object is properly preserved during the workbook save process for BarChart3D.

This addresses the issue where 3D rotation settings were not being retained after saving and reopening the workbook.

Ticket: https://foss.heptapod.net/openpyxl/openpyxl/-/issues/2234